### PR TITLE
Update base.html, remove tinymce

### DIFF
--- a/django_daisy/templates/admin/base.html
+++ b/django_daisy/templates/admin/base.html
@@ -175,7 +175,6 @@
 <script src="{% static "admin/js/jquery.init.js" %}"></script>
 <script src="{% static "admin/js/tom-select.complete.min.js.js" %}"></script>
 <script src="{% static "admin/js/theme-change.js" %}"></script>
-<script defer src="{% static 'admin/tinymce/tinymce.min.js' %}"></script>
 <script defer src="{% static 'admin/js/SelectBox.js' %}"></script>
 <script src="{% static 'admin/js/admin/dashboard.js' %}"></script>
 {% for custom_script_link in EXTRA_SCRIPTS %}


### PR DESCRIPTION
From commit history, tinymce has been removed. But it still being loaded in base template despite there are no tinymce script anymore. So, it need to be removed.